### PR TITLE
Change BDS Raven settings to use 'office-calendar' icon

### DIFF
--- a/src/panel/settings/settings_raven.vala
+++ b/src/panel/settings/settings_raven.vala
@@ -22,7 +22,7 @@ namespace Budgie {
 				content_id: "raven",
 				title: "Raven",
 				display_weight: 3,
-				icon_name: "preferences-calendar-and-tasks" // Subject to change
+				icon_name: "office-calendar" // Subject to change
 			);
 
 			border_width = 0;


### PR DESCRIPTION
## Description
This PR changes the icon used by Raven settings in Budgie Desktop Settings to use `office-calendar`, instead of `preferences-calendar-and-tasks`. This allows some icon themes to properly assign an icon to Raven settings, such as Breeze.


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
